### PR TITLE
Updates for offline audio rendering

### DIFF
--- a/TheAmazingAudioEngine/AEAudioController.h
+++ b/TheAmazingAudioEngine/AEAudioController.h
@@ -1333,6 +1333,12 @@ BOOL AECurrentThreadIsAudioThread(void);
  */
 OSStatus AEAudioControllerRenderMainOutput(AEAudioController *audioController, AudioTimeStamp inTimeStamp, UInt32 inNumberFrames, AudioBufferList *ioData);
 
+/*!
+ * Render specified channel group output into AudioBufferList.
+ * Use only while the AUGraph is not running.
+ */
+OSStatus AEAudioControllerRenderChannelGroupOutput(AEAudioController *audioController, AEChannelGroupRef channelGroup, AudioTimeStamp inTimeStamp, UInt32 inNumberFrames, AudioBufferList *ioData);
+
 ///@}
 #pragma mark - Properties
 

--- a/TheAmazingAudioEngine/AEAudioController.h
+++ b/TheAmazingAudioEngine/AEAudioController.h
@@ -1327,6 +1327,12 @@ NSTimeInterval AEConvertFramesToSeconds(__unsafe_unretained AEAudioController *a
  */
 BOOL AECurrentThreadIsAudioThread(void);
 
+/*!
+ * Render main output into AudioBufferList.
+ * Use only while the AUGraph is not running.
+ */
+OSStatus AEAudioControllerRenderMainOutput(AEAudioController *audioController, AudioTimeStamp inTimeStamp, UInt32 inNumberFrames, AudioBufferList *ioData);
+
 ///@}
 #pragma mark - Properties
 

--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -4019,10 +4019,19 @@ static void handleCallbacksForChannel(AEChannelRef channel, const AudioTimeStamp
 
 OSStatus AEAudioControllerRenderMainOutput(AEAudioController *audioController, AudioTimeStamp inTimeStamp, UInt32 inNumberFrames, AudioBufferList *ioData) {
 
+    return AEAudioControllerRenderChannelGroupOutput(audioController,
+                                                     audioController->_topGroup,
+                                                     inTimeStamp,
+                                                     inNumberFrames,
+                                                     ioData);
+}
+
+OSStatus AEAudioControllerRenderChannelGroupOutput(AEAudioController *audioController, AEChannelGroupRef channelGroup, AudioTimeStamp inTimeStamp, UInt32 inNumberFrames, AudioBufferList *ioData) {
+
     AudioUnitRenderActionFlags actionFlags = kAudioOfflineUnitRenderAction_Render;
 
     channel_producer_arg_t arg = {
-        .channel = audioController->_topChannel,
+        .channel = channelGroup->channel,
         .timeStamp = inTimeStamp,
         .originalTimeStamp = inTimeStamp,
         .ioActionFlags = &actionFlags,

--- a/TheAmazingAudioEngine/AEAudioController.m
+++ b/TheAmazingAudioEngine/AEAudioController.m
@@ -4017,6 +4017,22 @@ static void handleCallbacksForChannel(AEChannelRef channel, const AudioTimeStamp
 
 #pragma mark - Assorted helpers
 
+OSStatus AEAudioControllerRenderMainOutput(AEAudioController *audioController, AudioTimeStamp inTimeStamp, UInt32 inNumberFrames, AudioBufferList *ioData) {
+
+    AudioUnitRenderActionFlags actionFlags = kAudioOfflineUnitRenderAction_Render;
+
+    channel_producer_arg_t arg = {
+        .channel = audioController->_topChannel,
+        .timeStamp = inTimeStamp,
+        .originalTimeStamp = inTimeStamp,
+        .ioActionFlags = &actionFlags,
+        .nextFilterIndex = 0
+    };
+    OSStatus result = channelAudioProducer((void*)&arg, ioData, &inNumberFrames);
+    handleCallbacksForChannel(arg.channel, &inTimeStamp, inNumberFrames, ioData);
+    return result;
+}
+
 static void performLevelMonitoring(audio_level_monitor_t* monitor, AudioBufferList *buffer, UInt32 numberFrames) {
     if ( !monitor->floatConverter || !monitor->scratchBuffer ) return;
     

--- a/TheAmazingAudioEngine/AEMessageQueue.h
+++ b/TheAmazingAudioEngine/AEMessageQueue.h
@@ -87,9 +87,9 @@ typedef void (*AEMessageQueueMessageHandler)(void *userInfo, int userInfoLength)
 - (void)stopPolling;
 
 /*!
- * Clear messages in the queue without executing their callbacks
+ * Process messages in the queue
  */
-- (void)clearQueue;
+- (void)pollForMessageResponses;
 
 /*!
  * Send a message to the realtime thread asynchronously, optionally receiving a response via a block

--- a/TheAmazingAudioEngine/AEMessageQueue.h
+++ b/TheAmazingAudioEngine/AEMessageQueue.h
@@ -87,6 +87,11 @@ typedef void (*AEMessageQueueMessageHandler)(void *userInfo, int userInfoLength)
 - (void)stopPolling;
 
 /*!
+ * Clear messages in the queue without executing their callbacks
+ */
+- (void)clearQueue;
+
+/*!
  * Send a message to the realtime thread asynchronously, optionally receiving a response via a block
  *
  *  This is a synchronization mechanism that allows you to schedule actions to be performed 

--- a/TheAmazingAudioEngine/AEMessageQueue.m
+++ b/TheAmazingAudioEngine/AEMessageQueue.m
@@ -138,7 +138,7 @@ void AEMessageQueueProcessMessagesOnRealtimeThread(__unsafe_unretained AEMessage
     }
 }
 
-- (void)pollForMessageResponses {
+-(void)pollForMessageResponses {
     pthread_t thread = pthread_self();
     BOOL isMainThread = [NSThread isMainThread];
 

--- a/TheAmazingAudioEngine/AEMessageQueue.m
+++ b/TheAmazingAudioEngine/AEMessageQueue.m
@@ -138,15 +138,7 @@ void AEMessageQueueProcessMessagesOnRealtimeThread(__unsafe_unretained AEMessage
     }
 }
 
-- (void)clearQueue {
-    [self processMessagesAndExecute:NO];
-}
-
 - (void)pollForMessageResponses {
-    [self processMessagesAndExecute:YES];
-}
-
-- (void)processMessagesAndExecute:(BOOL)executeMessages {
     pthread_t thread = pthread_self();
     BOOL isMainThread = [NSThread isMainThread];
 
@@ -196,9 +188,7 @@ void AEMessageQueueProcessMessagesOnRealtimeThread(__unsafe_unretained AEMessage
         }
         
         if ( message->responseBlock ) {
-            if ( executeMessages ) {
-                ((__bridge void(^)())message->responseBlock)();
-            }
+            ((__bridge void(^)())message->responseBlock)();
             CFBridgingRelease(message->responseBlock);
             
             _pendingResponses--;
@@ -206,10 +196,8 @@ void AEMessageQueueProcessMessagesOnRealtimeThread(__unsafe_unretained AEMessage
                 _pollThread.pollInterval = kIdleMessagingPollDuration;
             }
         } else if ( message->handler ) {
-            if ( executeMessages ) {
-                message->handler(message->userInfoLength > 0 ? message+1 : NULL,
-                                 message->userInfoLength);
-            }
+            message->handler(message->userInfoLength > 0 ? message+1 : NULL,
+                             message->userInfoLength);
         }
         
         if ( message->block ) {


### PR DESCRIPTION
1. Adds global `AEAudioControllerRenderMainOutput` and `AEAudioControllerRenderChannelGroupOutput` that allows us to pull frames from the AUGraph while it's stopped.
2. Public `pollForMessageResponses` on `AEMessageQueue`. This is useful for offline processing because the messaging system isn't built for non-real-time messaging, so we have to manually trigger the processing of those messages.
